### PR TITLE
Fix MIPS template reference

### DIFF
--- a/data/payment_provider_data.xml
+++ b/data/payment_provider_data.xml
@@ -3,6 +3,6 @@
     <field name="name">MIPS</field>
     <field name="code">mips</field>
     <field name="state">test</field>
-    <field name="view_template_id" ref="payment_mips.mips_payment_template"/>
+    <field name="view_template_id" ref="mips_payment_gateway.mips_payment_template"/>
   </record>
 </odoo>

--- a/views/mips_payment_template.xml
+++ b/views/mips_payment_template.xml
@@ -1,6 +1,6 @@
 <odoo>
   <template id="mips_payment_template">
-    <t t-name="payment_mips.mips_payment_template">
+    <t t-name="mips_payment_gateway.mips_payment_template">
       <div class="mips-gateway-wrapper">
         <p>Use your MIPS credentials here…</p>
         <!-- Add custom form fields here -->


### PR DESCRIPTION
## Summary
- fix XML ID reference to match module folder name
- update template tag name

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6842133810bc832cb41e6e31ab3150ff